### PR TITLE
Update .gitignore to exclude ".lock" files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 node_modules/
 
 dist/
+
+#no track PM's locka files.
+yarn.lock
+package.lock.json


### PR DESCRIPTION
Excluir los archivos "lock" de yarn y npm.